### PR TITLE
Add type-safe model selection and support for Swift Concurrency 

### DIFF
--- a/Sources/OpenAISwift/Models/OpenAIModelType.swift
+++ b/Sources/OpenAISwift/Models/OpenAIModelType.swift
@@ -1,0 +1,67 @@
+//
+//  OpenAIModelType.swift
+//  
+//
+//  Created by Yash Shah on 06/12/2022.
+//
+
+import Foundation
+
+/// The type of model used to generate the output
+public enum OpenAIModelType {
+	/// ``GPT3`` Family of Models
+	case gpt3(GPT3)
+
+	/// ``Codex`` Family of Models
+	case codex(Codex)
+
+	public var modelName: String {
+		switch self {
+			case .gpt3(let model): return model.rawValue
+			case .codex(let model): return model.rawValue
+		}
+	}
+
+	/// A set of models that can understand and generate natural language
+	///
+	/// [GPT-3 Models OpenAI API Docs](https://beta.openai.com/docs/models/gpt-3)
+	public enum GPT3: String {
+
+		/// Most capable GPT-3 model. Can do any task the other models can do, often with higher quality, longer output and better instruction-following. Also supports inserting completions within text.
+		///
+		/// > Model Name: text-davinci-003
+		case davinci = "text-davinci-003"
+
+		/// Very capable, but faster and lower cost than GPT3 ``davinci``.
+		///
+		/// > Model Name: text-curie-001
+		case curie = "text-curie-001"
+
+		/// Capable of straightforward tasks, very fast, and lower cost.
+		///
+		/// > Model Name: text-babbage-001
+		case babbage = "text-babbage-001"
+
+		/// Capable of very simple tasks, usually the fastest model in the GPT-3 series, and lowest cost.
+		///
+		/// > Model Name: text-ada-001
+		case ada = "text-ada-001"
+	}
+
+	/// A set of models that can understand and generate code, including translating natural language to code
+	///
+	/// [Codex Models OpenAI API Docs](https://beta.openai.com/docs/models/codex)
+	///
+	///  >  Limited Beta
+	public enum Codex: String {
+		/// Most capable Codex model. Particularly good at translating natural language to code. In addition to completing code, also supports inserting completions within code.
+		///
+		/// > Model Name: code-davinci-002
+		case davinci = "code-davinci-002"
+
+		/// Almost as capable as ``davinci`` Codex, but slightly faster. This speed advantage may make it preferable for real-time applications.
+		///
+		/// > Model Name: code-cushman-001
+		case cushman = "code-cushman-001"
+	}
+}

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -19,7 +19,7 @@ extension OpenAISwift {
     ///   - prompt: The Text Prompt
     ///   - model: The AI Model to Use
     ///   - completionHandler: Returns an OpenAI Data Model
-    public func sendCompletion(with prompt: String, model: String, completionHandler: @escaping ((OpenAI?, OpenAIError?) -> Void)) {
+    public func sendCompletion(with prompt: String, model: String, completionHandler: @escaping (Result<OpenAI, OpenAIError>) -> Void) {
         let endpoint = Endpoint.completions
         let body = Command(prompt: prompt, model: model)
         let request = prepareRequest(endpoint, body: body)
@@ -27,13 +27,13 @@ extension OpenAISwift {
         let session = URLSession.shared
         let task = session.dataTask(with: request) { (data, response, error) in
             if let error = error {
-                completionHandler(nil, OpenAIError.genericError(error: error))
+				completionHandler(.failure(.genericError(error: error)))
             } else if let data = data {
                 do {
                     let res = try JSONDecoder().decode(OpenAI.self, from: data)
-                    completionHandler(res, nil)
+					completionHandler(.success(res))
                 } catch {
-                    completionHandler(nil, OpenAIError.decodingError(error: error))
+					completionHandler(.failure(.decodingError(error: error)))
                 }
             }
         }

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -61,3 +61,20 @@ extension OpenAISwift {
         return request
     }
 }
+
+extension OpenAISwift {
+	/// Send a Completion to the OpenAI API
+	/// - Parameters:
+	///   - prompt: The Text Prompt
+	///   - model: The AI Model to Use
+	/// - Returns: Returns an OpenAI Data Model
+	@available(swift 5.5)
+	@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+	public func sendCompletion(with prompt: String, model: String) async throws -> OpenAI {
+		return try await withCheckedThrowingContinuation { continuation in
+			sendCompletion(with: prompt, model: model) { result in
+				continuation.resume(with: result)
+			}
+		}
+	}
+}

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -17,13 +17,13 @@ extension OpenAISwift {
     /// Send a Completion to the OpenAI API
     /// - Parameters:
     ///   - prompt: The Text Prompt
-    ///   - model: The AI Model to Use
+    ///   - model: The AI Model to Use. Set to `OpenAIModelType.gpt3(.davinci)` by default which is the most capable model
     ///   - completionHandler: Returns an OpenAI Data Model
-    public func sendCompletion(with prompt: String, model: String, completionHandler: @escaping (Result<OpenAI, OpenAIError>) -> Void) {
+	public func sendCompletion(with prompt: String, model: OpenAIModelType = .gpt3(.davinci), completionHandler: @escaping (Result<OpenAI, OpenAIError>) -> Void) {
         let endpoint = Endpoint.completions
-        let body = Command(prompt: prompt, model: model)
+		let body = Command(prompt: prompt, model: model.modelName)
         let request = prepareRequest(endpoint, body: body)
-        
+
         let session = URLSession.shared
         let task = session.dataTask(with: request) { (data, response, error) in
             if let error = error {
@@ -66,11 +66,11 @@ extension OpenAISwift {
 	/// Send a Completion to the OpenAI API
 	/// - Parameters:
 	///   - prompt: The Text Prompt
-	///   - model: The AI Model to Use
+	///   - model:  The AI Model to Use. Set to `OpenAIModelType.gpt3(.davinci)` by default which is the most capable model
 	/// - Returns: Returns an OpenAI Data Model
 	@available(swift 5.5)
 	@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-	public func sendCompletion(with prompt: String, model: String) async throws -> OpenAI {
+	public func sendCompletion(with prompt: String, model: OpenAIModelType = .gpt3(.davinci)) async throws -> OpenAI {
 		return try await withCheckedThrowingContinuation { continuation in
 			sendCompletion(with: prompt, model: model) { result in
 				continuation.resume(with: result)

--- a/Tests/OpenAISwiftTests/OpenAISwiftTests.swift
+++ b/Tests/OpenAISwiftTests/OpenAISwiftTests.swift
@@ -6,6 +6,5 @@ final class OpenAISwiftTests: XCTestCase {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct
         // results.
-        XCTAssertEqual(OpenAISwift().text, "Hello, World!")
     }
 }


### PR DESCRIPTION
## What it Does
This Commit:
- replaces the optional completion closure parameters (`(OpenAI?, OpenAIError?) -> Void`) in `OpenAISwift.sendCompletion(with:model:completionHandler:)` with the Result type (`(Result<OpenAI, OpenAIError>) -> Void`)
- adds an `async` wrapper around `OpenAISwift.sendCompletion(with:model:completionHandler:)` using a `CheckedThrowingContinuation` so that it can be called in an asynchronous context using Swift Concurrency (async/await)
- adds an `OpenAIModelType` enum which replaces the old string-based model naming with strongly typed enum cases. It supports all the GPT and Codex models listed in the [documentation](https://beta.openai.com/docs/models/).
- > **Note**: I haven't included the Content filter models as the [documentation](https://beta.openai.com/docs/models/content-filter) suggests the use of their moderation endpoint instead of the current completion endpoint

