### PR TITLE
Adding max_tokens to the API call

### DIFF
--- a/Sources/OpenAISwift/Models/Command.swift
+++ b/Sources/OpenAISwift/Models/Command.swift
@@ -7,14 +7,17 @@ import Foundation
 class Command: Encodable {
     var prompt: String
     var model: String
+    var maxTokens: Int
     
-    init(prompt: String, model: String) {
+    init(prompt: String, model: String, maxTokens: Int) {
         self.prompt = prompt
         self.model = model
+        self.maxTokens = maxTokens
     }
     
     enum CodingKeys: String, CodingKey {
         case prompt
         case model
+        case maxTokens = "max_tokens"
     }
 }

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -14,13 +14,13 @@ public class OpenAISwift {
 }
 
 extension OpenAISwift {
-    /// Send a Completion to the OpenAI API
-    /// - Parameters:
-    ///   - prompt: The Text Prompt
-    ///   - model: The AI Model to Use. Set to `OpenAIModelType.gpt3(.davinci)` by default which is the most capable model
-    ///   - maxTokens: The limit character for the returned response, defaults to 16 as per the API
-    ///   - completionHandler: Returns an OpenAI Data Model
-    public func sendCompletion(with prompt: String, model: OpenAIModelType = .gpt3(.davinci), maxTokens: Int = 16, completionHandler: @escaping (Result<OpenAI, OpenAIError>) -> Void) {
+	/// Send a Completion to the OpenAI API
+	/// - Parameters:
+	///   - prompt: The Text Prompt
+	///   - model: The AI Model to Use. Set to `OpenAIModelType.gpt3(.davinci)` by default which is the most capable model
+	///   - maxTokens: The limit character for the returned response, defaults to 16 as per the API
+	///   - completionHandler: Returns an OpenAI Data Model
+	public func sendCompletion(with prompt: String, model: OpenAIModelType = .gpt3(.davinci), maxTokens: Int = 16, completionHandler: @escaping (Result<OpenAI, OpenAIError>) -> Void) {
         let endpoint = Endpoint.completions
 		let body = Command(prompt: prompt, model: model.modelName, maxTokens: maxTokens)
         let request = prepareRequest(endpoint, body: body)
@@ -67,8 +67,8 @@ extension OpenAISwift {
 	/// Send a Completion to the OpenAI API
 	/// - Parameters:
 	///   - prompt: The Text Prompt
-	///   - model:  The AI Model to Use. Set to `OpenAIModelType.gpt3(.davinci)` by default which is the most capable model
-    ///   - maxTokens:  The limit character for the returned response, defaults to 16 as per the API
+	///   - model: The AI Model to Use. Set to `OpenAIModelType.gpt3(.davinci)` by default which is the most capable model
+	///   - maxTokens: The limit character for the returned response, defaults to 16 as per the API
 	/// - Returns: Returns an OpenAI Data Model
 	@available(swift 5.5)
 	@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -18,10 +18,11 @@ extension OpenAISwift {
     /// - Parameters:
     ///   - prompt: The Text Prompt
     ///   - model: The AI Model to Use. Set to `OpenAIModelType.gpt3(.davinci)` by default which is the most capable model
+    ///   - maxTokens: The limit character for the returned response, defaults to 16 as per the API
     ///   - completionHandler: Returns an OpenAI Data Model
-	public func sendCompletion(with prompt: String, model: OpenAIModelType = .gpt3(.davinci), completionHandler: @escaping (Result<OpenAI, OpenAIError>) -> Void) {
+    public func sendCompletion(with prompt: String, model: OpenAIModelType = .gpt3(.davinci), maxTokens: Int = 16, completionHandler: @escaping (Result<OpenAI, OpenAIError>) -> Void) {
         let endpoint = Endpoint.completions
-		let body = Command(prompt: prompt, model: model.modelName)
+		let body = Command(prompt: prompt, model: model.modelName, maxTokens: maxTokens)
         let request = prepareRequest(endpoint, body: body)
 
         let session = URLSession.shared
@@ -67,12 +68,13 @@ extension OpenAISwift {
 	/// - Parameters:
 	///   - prompt: The Text Prompt
 	///   - model:  The AI Model to Use. Set to `OpenAIModelType.gpt3(.davinci)` by default which is the most capable model
+    ///   - maxTokens:  The limit character for the returned response, defaults to 16 as per the API
 	/// - Returns: Returns an OpenAI Data Model
 	@available(swift 5.5)
 	@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-	public func sendCompletion(with prompt: String, model: OpenAIModelType = .gpt3(.davinci)) async throws -> OpenAI {
+	public func sendCompletion(with prompt: String, model: OpenAIModelType = .gpt3(.davinci), maxTokens: Int = 16) async throws -> OpenAI {
 		return try await withCheckedThrowingContinuation { continuation in
-			sendCompletion(with: prompt, model: model) { result in
+			sendCompletion(with: prompt, model: model, maxTokens: maxTokens) { result in
 				continuation.resume(with: result)
 			}
 		}


### PR DESCRIPTION
# Description

The OpenAI API allows you to send the max_tokens to limit the response coming back but also to prevent huge usage of the API. The default is 16 but we should allow consumers to override this value.

Fixes [(3)](https://github.com/adamrushy/OpenAISwift/issues/3)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)