### PR TITLE
Updated OpenAI link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 # OpenAI API Client Library in Swift
 
 This is a community-maintained library to access OpenAI HTTP API's. The full API docs can be found here:
-https://beta.openai.com/api-docs
+https://beta.openai.com/docs
 
 ## Installation 💻
 


### PR DESCRIPTION
On clicking https://beta.openai.com/api-docs, it presents a 404 page
I edited the link to the correct link which is: https://beta.openai.com/docs