### PR TITLE
Adding support for Swift 5.5 to include Xcode 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
We currently only support Xcode 14 with Swift 5.7, we can lower this support to Swift 5.5 to include Xcode 13.