### PR TITLE
Fixed indentation in README sample code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ OpenAISwift also supports Swift concurrency so you can use Swift’s async/await
 
 ```swift
 do {
-	let result = try await openAPI.sendCompletion(with: "A random emoji")
+    let result = try await openAPI.sendCompletion(with: "A random emoji")
 } catch {
-	print(error.localizedDescription)
+    print(error.localizedDescription)
 }
 ```
 


### PR DESCRIPTION
Hi, the indentation of the sample code in the README was different from the other sample code, so I unified it so that they are the same.