### PR TITLE
support for ChatGPT's gpt-3.5-turbo model

### DIFF
--- a/Sources/OpenAISwift/Models/Command.swift
+++ b/Sources/OpenAISwift/Models/Command.swift
@@ -17,3 +17,17 @@ struct Command: Encodable {
         case temperature
     }
 }
+
+struct ChatCommand: Encodable {
+    let messages: [Message]
+    let model: String
+    let maxTokens: Int
+    let temperature: Double
+    
+    enum CodingKeys: String, CodingKey {
+        case messages
+        case model
+        case maxTokens = "max_tokens"
+        case temperature
+    }
+}

--- a/Sources/OpenAISwift/Models/OpenAI.swift
+++ b/Sources/OpenAISwift/Models/OpenAI.swift
@@ -4,12 +4,32 @@
 
 import Foundation
 
-public struct OpenAI: Codable {
+public struct CompletionResponse: Codable {
     public let object: String
-    public let model: String?
-    public let choices: [Choice]
+    public let model: String
+    public let choices: [CompletionChoice]
 }
 
-public struct Choice: Codable {
+public struct CompletionChoice: Codable {
     public let text: String
+}
+
+public struct ChatResponse: Codable {
+    public let object: String
+    public let model: String
+    public let choices: [ChatChoice]
+}
+
+public struct ChatChoice: Codable {
+    public let message: Message
+}
+
+public struct Message: Codable {
+    public let role: String
+    public let content: String
+    
+    public init(role: String, content: String) {
+        self.role = role
+        self.content = content
+    }
 }

--- a/Sources/OpenAISwift/Models/OpenAIModelType.swift
+++ b/Sources/OpenAISwift/Models/OpenAIModelType.swift
@@ -31,6 +31,11 @@ public enum OpenAIModelType {
     /// [GPT-3 Models OpenAI API Docs](https://beta.openai.com/docs/models/gpt-3)
     public enum GPT3: String {
         
+        /// Most capable GPT-3.5 model and optimized for chat at 1/10th the cost of text-davinci-003. Will be updated with our latest model iteration.
+        ///
+        /// > Model Name: gpt-3.5-turbo
+        case chatgpt = "gpt-3.5-turbo"
+        
         /// Most capable GPT-3 model. Can do any task the other models can do, often with higher quality, longer output and better instruction-following. Also supports inserting completions within text.
         ///
         /// > Model Name: text-davinci-003

--- a/Sources/OpenAISwift/OpenAIEndpoint.swift
+++ b/Sources/OpenAISwift/OpenAIEndpoint.swift
@@ -5,6 +5,7 @@
 import Foundation
 
 enum Endpoint {
+    case chat
     case completions
     case edits
 }
@@ -12,6 +13,8 @@ enum Endpoint {
 extension Endpoint {
     var path: String {
         switch self {
+        case .chat:
+            return "/v1/chat/completions"
         case .completions:
             return "/v1/completions"
         case .edits:
@@ -21,14 +24,14 @@ extension Endpoint {
     
     var method: String {
         switch self {
-        case .completions, .edits:
+        case .chat, .completions, .edits:
             return "POST"
         }
     }
     
     func baseURL() -> String {
         switch self {
-        case .completions, .edits:
+        case .chat, .completions, .edits:
             return "https://api.openai.com"
         }
     }

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -18,13 +18,39 @@ public class OpenAISwift {
 }
 
 extension OpenAISwift {
+    /// Send a Chat to the OpenAI API
+    /// - Parameters:
+    ///   - messages: The messages to generate chat completions for
+    ///   - model: The AI Model to Use. Set to `OpenAIModelType.gpt3(.turbo)` by default which is the most capable model
+    ///   - maxTokens: The limit character for the returned response, defaults to 4096 as per the API
+    ///   - completionHandler: Returns an OpenAI Data Model
+    public func sendChat(with messages: [Message], model: OpenAIModelType = .gpt3(.chatgpt), maxTokens: Int = 4096, temperature: Double = 1, completionHandler: @escaping (Result<ChatResponse, OpenAIError>) -> Void) {
+        let endpoint = Endpoint.chat
+        let body = ChatCommand(messages: messages, model: model.modelName, maxTokens: maxTokens, temperature: temperature)
+        let request = prepareRequest(endpoint, body: body)
+        
+        makeRequest(request: request) { result in
+            switch result {
+            case .success(let success):
+                do {
+                    let res = try JSONDecoder().decode(ChatResponse.self, from: success)
+                    completionHandler(.success(res))
+                } catch {
+                    completionHandler(.failure(.decodingError(error: error)))
+                }
+            case .failure(let failure):
+                completionHandler(.failure(.genericError(error: failure)))
+            }
+        }
+    }
+    
     /// Send a Completion to the OpenAI API
     /// - Parameters:
     ///   - prompt: The Text Prompt
     ///   - model: The AI Model to Use. Set to `OpenAIModelType.gpt3(.davinci)` by default which is the most capable model
     ///   - maxTokens: The limit character for the returned response, defaults to 16 as per the API
     ///   - completionHandler: Returns an OpenAI Data Model
-    public func sendCompletion(with prompt: String, model: OpenAIModelType = .gpt3(.davinci), maxTokens: Int = 16, temperature: Double = 1, completionHandler: @escaping (Result<OpenAI, OpenAIError>) -> Void) {
+    public func sendCompletion(with prompt: String, model: OpenAIModelType = .gpt3(.davinci), maxTokens: Int = 16, temperature: Double = 1, completionHandler: @escaping (Result<CompletionResponse, OpenAIError>) -> Void) {
         let endpoint = Endpoint.completions
         let body = Command(prompt: prompt, model: model.modelName, maxTokens: maxTokens, temperature: temperature)
         let request = prepareRequest(endpoint, body: body)
@@ -33,7 +59,7 @@ extension OpenAISwift {
             switch result {
             case .success(let success):
                 do {
-                    let res = try JSONDecoder().decode(OpenAI.self, from: success)
+                    let res = try JSONDecoder().decode(CompletionResponse.self, from: success)
                     completionHandler(.success(res))
                 } catch {
                     completionHandler(.failure(.decodingError(error: error)))
@@ -50,7 +76,7 @@ extension OpenAISwift {
     ///   - model: The Model to use, the only support model is `text-davinci-edit-001`
     ///   - input: The Input For Example "My nam is Adam"
     ///   - completionHandler: Returns an OpenAI Data Model
-    public func sendEdits(with instruction: String, model: OpenAIModelType = .feature(.davinci), input: String = "", completionHandler: @escaping (Result<OpenAI, OpenAIError>) -> Void) {
+    public func sendEdits(with instruction: String, model: OpenAIModelType = .feature(.davinci), input: String = "", completionHandler: @escaping (Result<CompletionResponse, OpenAIError>) -> Void) {
         let endpoint = Endpoint.edits
         let body = Instruction(instruction: instruction, model: model.modelName, input: input)
         let request = prepareRequest(endpoint, body: body)
@@ -59,7 +85,7 @@ extension OpenAISwift {
             switch result {
             case .success(let success):
                 do {
-                    let res = try JSONDecoder().decode(OpenAI.self, from: success)
+                    let res = try JSONDecoder().decode(CompletionResponse.self, from: success)
                     completionHandler(.success(res))
                 } catch {
                     completionHandler(.failure(.decodingError(error: error)))
@@ -105,6 +131,22 @@ extension OpenAISwift {
 }
 
 extension OpenAISwift {
+    /// Send a Chat to the OpenAI API
+    /// - Parameters:
+    ///   - messages: The messages to generate chat completions for
+    ///   - model: The AI Model to Use. Set to `OpenAIModelType.gpt3(.turbo)` by default which is the most capable model
+    ///   - maxTokens: The limit character for the returned response, defaults to 4096 as per the API
+    ///   - completionHandler: Returns an OpenAI Data Model
+    @available(swift 5.5)
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    public func sendChat(with messages: [Message], model: OpenAIModelType = .gpt3(.chatgpt), maxTokens: Int = 4096, temperature: Double = 1) async throws -> ChatResponse {
+        return try await withCheckedThrowingContinuation { continuation in
+            sendChat(with: messages, model: model, maxTokens: maxTokens, temperature: temperature) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+    
     /// Send a Completion to the OpenAI API
     /// - Parameters:
     ///   - prompt: The Text Prompt
@@ -114,7 +156,7 @@ extension OpenAISwift {
     /// - Returns: Returns an OpenAI Data Model
     @available(swift 5.5)
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-    public func sendCompletion(with prompt: String, model: OpenAIModelType = .gpt3(.davinci), maxTokens: Int = 16, temperature: Double = 1) async throws -> OpenAI {
+    public func sendCompletion(with prompt: String, model: OpenAIModelType = .gpt3(.davinci), maxTokens: Int = 16, temperature: Double = 1) async throws -> CompletionResponse {
         return try await withCheckedThrowingContinuation { continuation in
             sendCompletion(with: prompt, model: model, maxTokens: maxTokens, temperature: temperature) { result in
                 continuation.resume(with: result)
@@ -130,7 +172,7 @@ extension OpenAISwift {
     ///   - completionHandler: Returns an OpenAI Data Model
     @available(swift 5.5)
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-    public func sendEdits(with instruction: String, model: OpenAIModelType = .feature(.davinci), input: String = "", completionHandler: @escaping (Result<OpenAI, OpenAIError>) -> Void) async throws -> OpenAI {
+    public func sendEdits(with instruction: String, model: OpenAIModelType = .feature(.davinci), input: String = "", completionHandler: @escaping (Result<CompletionResponse, OpenAIError>) -> Void) async throws -> CompletionResponse {
         return try await withCheckedThrowingContinuation { continuation in
             sendEdits(with: instruction, model: model, input: input) { result in
                 continuation.resume(with: result)

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -21,7 +21,7 @@ extension OpenAISwift {
     /// Send a Chat to the OpenAI API
     /// - Parameters:
     ///   - messages: The messages to generate chat completions for
-    ///   - model: The AI Model to Use. Set to `OpenAIModelType.gpt3(.turbo)` by default which is the most capable model
+    ///   - model: The AI Model to Use. Set to `OpenAIModelType.gpt3(.chatgpt)` by default which is the most capable model
     ///   - maxTokens: The limit character for the returned response, defaults to 4096 as per the API
     ///   - completionHandler: Returns an OpenAI Data Model
     public func sendChat(with messages: [Message], model: OpenAIModelType = .gpt3(.chatgpt), maxTokens: Int = 4096, temperature: Double = 1, completionHandler: @escaping (Result<ChatResponse, OpenAIError>) -> Void) {
@@ -134,7 +134,7 @@ extension OpenAISwift {
     /// Send a Chat to the OpenAI API
     /// - Parameters:
     ///   - messages: The messages to generate chat completions for
-    ///   - model: The AI Model to Use. Set to `OpenAIModelType.gpt3(.turbo)` by default which is the most capable model
+    ///   - model: The AI Model to Use. Set to `OpenAIModelType.gpt3(.chatgpt)` by default which is the most capable model
     ///   - maxTokens: The limit character for the returned response, defaults to 4096 as per the API
     ///   - completionHandler: Returns an OpenAI Data Model
     @available(swift 5.5)


### PR DESCRIPTION
Did some basic tests to make sure I didn't break anything with the old models since this uses a new endpoint but refactored some existing code for re-use.

Could probably use some work to better handle the new `messages` param in the chat response, but basic functionality is there for the new `gpt-3.5-turbo` model.