### PR TITLE
Yet another `gpt-3.5-turbo` model implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ do {
 
 The latest `gpt-3.5-turbo` model is available too : 
 
-```
+```swift
 func chat() async {
     do {
         let chat: [ChatMessage] = [

--- a/README.md
+++ b/README.md
@@ -68,6 +68,27 @@ do {
 }
 ```
 
+The latest `gpt-3.5-turbo` model is available too : 
+
+```
+func chat() async {
+    do {
+        let chat: [ChatMessage] = [
+            ChatMessage(role: .system, content: "You are a helpful assistant."),
+            ChatMessage(role: .user, content: "Who won the world series in 2020?"),
+            ChatMessage(role: .assistant, content: "The Los Angeles Dodgers won the World Series in 2020."),
+            ChatMessage(role: .user, content: "Where was it played?")
+        ]
+                    
+        let result = try await openAI.sendChat(with: chat)
+        
+        print(result.choices.first?.message?.content ?? "Nothing")
+    } catch {
+        print("Something went wrong")
+    }
+}
+```
+
 ## Contribute ❤️
 
 I created this mainly for fun, we can add more endpoints and explore the library even further. Feel free to raise a PR to help grow the library.

--- a/Sources/OpenAISwift/Models/ChatMessage.swift
+++ b/Sources/OpenAISwift/Models/ChatMessage.swift
@@ -12,8 +12,8 @@ public enum ChatRole: String, Codable {
 }
 
 public struct ChatMessage: Codable {
-    let role: ChatRole
-    let content: String
+    public let role: ChatRole
+    public let content: String
     
     public init(role: ChatRole, content: String) {
         self.role = role

--- a/Sources/OpenAISwift/Models/Messages.swift
+++ b/Sources/OpenAISwift/Models/Messages.swift
@@ -1,0 +1,27 @@
+//
+//  File.swift
+//  
+//
+//  Created by Bogdan Farca on 02.03.2023.
+//
+
+import Foundation
+
+public enum ChatRole: String, Codable {
+    case system, user, assistant
+}
+
+public struct ChatMessage: Codable {
+    let role: ChatRole
+    let content: String
+    
+    public init(role: ChatRole, content: String) {
+        self.role = role
+        self.content = content
+    }
+}
+
+public struct ChatConversation: Encodable {
+    let messages: [ChatMessage]
+    let model: String
+}

--- a/Sources/OpenAISwift/Models/OpenAI.swift
+++ b/Sources/OpenAISwift/Models/OpenAI.swift
@@ -11,5 +11,6 @@ public struct OpenAI: Codable {
 }
 
 public struct Choice: Codable {
-    public let text: String
+    public let text: String?
+    public let message: ChatMessage?
 }

--- a/Sources/OpenAISwift/Models/OpenAI.swift
+++ b/Sources/OpenAISwift/Models/OpenAI.swift
@@ -13,9 +13,9 @@ public struct OpenAI<T: Payload>: Codable {
 }
 
 public struct TextResult: Payload {
-    public let text: String?
+    public let text: String
 }
 
 public struct MessageResult: Payload {
-    public let message: ChatMessage?
+    public let message: ChatMessage
 }

--- a/Sources/OpenAISwift/Models/OpenAI.swift
+++ b/Sources/OpenAISwift/Models/OpenAI.swift
@@ -4,13 +4,18 @@
 
 import Foundation
 
-public struct OpenAI: Codable {
+public protocol Payload: Codable { }
+
+public struct OpenAI<T: Payload>: Codable {
     public let object: String
     public let model: String?
-    public let choices: [Choice]
+    public let choices: [T]
 }
 
-public struct Choice: Codable {
+public struct TextResult: Payload {
     public let text: String?
+}
+
+public struct MessageResult: Payload {
     public let message: ChatMessage?
 }

--- a/Sources/OpenAISwift/Models/OpenAIModelType.swift
+++ b/Sources/OpenAISwift/Models/OpenAIModelType.swift
@@ -18,11 +18,15 @@ public enum OpenAIModelType {
     /// ``Feature``Family of Models
     case feature(Feature)
     
+    /// ``Chat``Family of Models
+    case chat(Chat)
+    
     public var modelName: String {
         switch self {
         case .gpt3(let model): return model.rawValue
         case .codex(let model): return model.rawValue
         case .feature(let model): return model.rawValue
+        case .chat(let model): return model.rawValue
         }
     }
     
@@ -79,5 +83,18 @@ public enum OpenAIModelType {
         
         /// > Model Name: text-davinci-edit-001
         case davinci = "text-davinci-edit-001"
+    }
+    
+    /// A set of models for the new chat completions
+    ///  You can read the [API Docs](https://platform.openai.com/docs/api-reference/chat/create)
+    public enum Chat: String {
+        
+        /// Most capable GPT-3.5 model and optimized for chat at 1/10th the cost of text-davinci-003. Will be updated with our latest model iteration.
+        /// > Model Name: gpt-3.5-turbo
+        case chatgpt = "gpt-3.5-turbo"
+        
+        /// Snapshot of gpt-3.5-turbo from March 1st 2023. Unlike gpt-3.5-turbo, this model will not receive updates, and will only be supported for a three month period ending on June 1st 2023.
+        /// > Model Name: gpt-3.5-turbo-0301
+        case chatgpt0301 = "gpt-3.5-turbo-0301"
     }
 }

--- a/Sources/OpenAISwift/OpenAIEndpoint.swift
+++ b/Sources/OpenAISwift/OpenAIEndpoint.swift
@@ -7,28 +7,31 @@ import Foundation
 enum Endpoint {
     case completions
     case edits
+    case chat
 }
 
 extension Endpoint {
     var path: String {
         switch self {
-        case .completions:
-            return "/v1/completions"
-        case .edits:
-            return "/v1/edits"
+            case .completions:
+                return "/v1/completions"
+            case .edits:
+                return "/v1/edits"
+            case .chat:
+                return "/v1/chat/completions"
         }
     }
     
     var method: String {
         switch self {
-        case .completions, .edits:
+            case .completions, .edits, .chat:
             return "POST"
         }
     }
     
     func baseURL() -> String {
         switch self {
-        case .completions, .edits:
+            case .completions, .edits, .chat:
             return "https://api.openai.com"
         }
     }

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -24,7 +24,7 @@ extension OpenAISwift {
     ///   - model: The AI Model to Use. Set to `OpenAIModelType.gpt3(.davinci)` by default which is the most capable model
     ///   - maxTokens: The limit character for the returned response, defaults to 16 as per the API
     ///   - completionHandler: Returns an OpenAI Data Model
-    public func sendCompletion(with prompt: String, model: OpenAIModelType = .gpt3(.davinci), maxTokens: Int = 16, temperature: Double = 1, completionHandler: @escaping (Result<OpenAI, OpenAIError>) -> Void) {
+    public func sendCompletion(with prompt: String, model: OpenAIModelType = .gpt3(.davinci), maxTokens: Int = 16, temperature: Double = 1, completionHandler: @escaping (Result<OpenAI<TextResult>, OpenAIError>) -> Void) {
         let endpoint = Endpoint.completions
         let body = Command(prompt: prompt, model: model.modelName, maxTokens: maxTokens, temperature: temperature)
         let request = prepareRequest(endpoint, body: body)
@@ -33,7 +33,7 @@ extension OpenAISwift {
             switch result {
             case .success(let success):
                 do {
-                    let res = try JSONDecoder().decode(OpenAI.self, from: success)
+                    let res = try JSONDecoder().decode(OpenAI<TextResult>.self, from: success)
                     completionHandler(.success(res))
                 } catch {
                     completionHandler(.failure(.decodingError(error: error)))
@@ -50,7 +50,7 @@ extension OpenAISwift {
     ///   - model: The Model to use, the only support model is `text-davinci-edit-001`
     ///   - input: The Input For Example "My nam is Adam"
     ///   - completionHandler: Returns an OpenAI Data Model
-    public func sendEdits(with instruction: String, model: OpenAIModelType = .feature(.davinci), input: String = "", completionHandler: @escaping (Result<OpenAI, OpenAIError>) -> Void) {
+    public func sendEdits(with instruction: String, model: OpenAIModelType = .feature(.davinci), input: String = "", completionHandler: @escaping (Result<OpenAI<TextResult>, OpenAIError>) -> Void) {
         let endpoint = Endpoint.edits
         let body = Instruction(instruction: instruction, model: model.modelName, input: input)
         let request = prepareRequest(endpoint, body: body)
@@ -59,7 +59,7 @@ extension OpenAISwift {
             switch result {
             case .success(let success):
                 do {
-                    let res = try JSONDecoder().decode(OpenAI.self, from: success)
+                    let res = try JSONDecoder().decode(OpenAI<TextResult>.self, from: success)
                     completionHandler(.success(res))
                 } catch {
                     completionHandler(.failure(.decodingError(error: error)))
@@ -72,11 +72,10 @@ extension OpenAISwift {
     
     /// Send a Chat request to the OpenAI API
     /// - Parameters:
-    ///   - instruction: The Instruction For Example: "Fix the spelling mistake"
-    ///   - model: The Model to use, the only support model is `text-davinci-edit-001`
-    ///   - input: The Input For Example "My nam is Adam"
+    ///   - messages: Array of `ChatMessages`
+    ///   - model: The Model to use, the only support model is `gpt-3.5-turbo`
     ///   - completionHandler: Returns an OpenAI Data Model
-    public func sendChat(with messages: [ChatMessage], model: OpenAIModelType = .chat(.chatgpt), completionHandler: @escaping (Result<OpenAI, OpenAIError>) -> Void) {
+    public func sendChat(with messages: [ChatMessage], model: OpenAIModelType = .chat(.chatgpt), completionHandler: @escaping (Result<OpenAI<MessageResult>, OpenAIError>) -> Void) {
         let endpoint = Endpoint.chat
         let body = ChatConversation(messages: messages, model: model.modelName)
         let request = prepareRequest(endpoint, body: body)
@@ -85,7 +84,7 @@ extension OpenAISwift {
             switch result {
                 case .success(let success):
                     do {
-                        let res = try JSONDecoder().decode(OpenAI.self, from: success)
+                        let res = try JSONDecoder().decode(OpenAI<MessageResult>.self, from: success)
                         completionHandler(.success(res))
                     } catch {
                         completionHandler(.failure(.decodingError(error: error)))
@@ -140,7 +139,7 @@ extension OpenAISwift {
     /// - Returns: Returns an OpenAI Data Model
     @available(swift 5.5)
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-    public func sendCompletion(with prompt: String, model: OpenAIModelType = .gpt3(.davinci), maxTokens: Int = 16, temperature: Double = 1) async throws -> OpenAI {
+    public func sendCompletion(with prompt: String, model: OpenAIModelType = .gpt3(.davinci), maxTokens: Int = 16, temperature: Double = 1) async throws -> OpenAI<TextResult> {
         return try await withCheckedThrowingContinuation { continuation in
             sendCompletion(with: prompt, model: model, maxTokens: maxTokens, temperature: temperature) { result in
                 continuation.resume(with: result)
@@ -156,9 +155,24 @@ extension OpenAISwift {
     /// - Returns: Returns an OpenAI Data Model
     @available(swift 5.5)
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-    public func sendEdits(with instruction: String, model: OpenAIModelType = .feature(.davinci), input: String = "") async throws -> OpenAI {
+    public func sendEdits(with instruction: String, model: OpenAIModelType = .feature(.davinci), input: String = "") async throws -> OpenAI<TextResult> {
         return try await withCheckedThrowingContinuation { continuation in
             sendEdits(with: instruction, model: model, input: input) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+    
+    /// Send a Chat request to the OpenAI API
+    /// - Parameters:
+    ///   - messages: Array of `ChatMessages`
+    ///   - model: The Model to use, the only support model is `gpt-3.5-turbo`
+    ///   - completionHandler: Returns an OpenAI Data Model
+    @available(swift 5.5)
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    public func sendChat(with messages: [ChatMessage], model: OpenAIModelType = .chat(.chatgpt)) async throws -> OpenAI<MessageResult> {
+        return try await withCheckedThrowingContinuation { continuation in
+            sendChat(with: messages, model: model) { result in
                 continuation.resume(with: result)
             }
         }

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -70,6 +70,32 @@ extension OpenAISwift {
         }
     }
     
+    /// Send a Chat request to the OpenAI API
+    /// - Parameters:
+    ///   - instruction: The Instruction For Example: "Fix the spelling mistake"
+    ///   - model: The Model to use, the only support model is `text-davinci-edit-001`
+    ///   - input: The Input For Example "My nam is Adam"
+    ///   - completionHandler: Returns an OpenAI Data Model
+    public func sendChat(with messages: [ChatMessage], model: OpenAIModelType = .chat(.chatgpt), completionHandler: @escaping (Result<OpenAI, OpenAIError>) -> Void) {
+        let endpoint = Endpoint.chat
+        let body = ChatConversation(messages: messages, model: model.modelName)
+        let request = prepareRequest(endpoint, body: body)
+        
+        makeRequest(request: request) { result in
+            switch result {
+                case .success(let success):
+                    do {
+                        let res = try JSONDecoder().decode(OpenAI.self, from: success)
+                        completionHandler(.success(res))
+                    } catch {
+                        completionHandler(.failure(.decodingError(error: error)))
+                    }
+                case .failure(let failure):
+                    completionHandler(.failure(.genericError(error: failure)))
+            }
+        }
+    }
+    
     private func makeRequest(request: URLRequest, completionHandler: @escaping (Result<Data, Error>) -> Void) {
         let session = URLSession.shared
         let task = session.dataTask(with: request) { (data, response, error) in


### PR DESCRIPTION
Did my own implementation in parallel with others. I like mine a little bit better, it uses generics to model the various responses coming from the the old endpoints and the new `chat` endpoint.