### PR TITLE
Added user, temperature, topProbabilityMass, choices, stop, presencePenalty, frequencyPenalty parameters to ChatConversation and sendChat functions.

### DIFF
--- a/Sources/OpenAISwift/Models/ChatMessage.swift
+++ b/Sources/OpenAISwift/Models/ChatMessage.swift
@@ -1,6 +1,6 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by Bogdan Farca on 02.03.2023.
 //
@@ -22,14 +22,28 @@ public struct ChatMessage: Codable {
 }
 
 public struct ChatConversation: Encodable {
+    let user: String?
     let messages: [ChatMessage]
     let model: String
+    let temperature: Double?
+    let topProbabilityMass: Double?
+    let choices: Int?
+    let stop: [String]?
     let maxTokens: Int?
+    let presencePenalty: Double?
+    let frequencyPenalty: Double?
 
     enum CodingKeys: String, CodingKey {
+        case user
         case messages
         case model
+        case temperature
+        case topProbabilityMass = "top_p"
+        case choices = "n"
+        case stop
         case maxTokens = "max_tokens"
+        case presencePenalty = "presence_penalty"
+        case frequencyPenalty = "frequency_penalty"
     }
 
 }

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -74,10 +74,37 @@ extension OpenAISwift {
     /// - Parameters:
     ///   - messages: Array of `ChatMessages`
     ///   - model: The Model to use, the only support model is `gpt-3.5-turbo`
+    ///   - user: A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+    ///   - temperature: What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. We generally recommend altering this or topProbabilityMass but not both.
+    ///   - topProbabilityMass: The OpenAI api equivalent of the "top_p" parameter. An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both.
+    ///   - choices: How many chat completion choices to generate for each input message.
+    ///   - stop: Up to 4 sequences where the API will stop generating further tokens.
+    ///   - maxTokens: The maximum number of tokens allowed for the generated answer. By default, the number of tokens the model can return will be (4096 - prompt tokens).
+    ///   - presencePenalty: Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.
+    ///   - frequencyPenalty: Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.
     ///   - completionHandler: Returns an OpenAI Data Model
-    public func sendChat(with messages: [ChatMessage], model: OpenAIModelType = .chat(.chatgpt), maxTokens: Int? = nil, completionHandler: @escaping (Result<OpenAI<MessageResult>, OpenAIError>) -> Void) {
+    public func sendChat(with messages: [ChatMessage],
+                         model: OpenAIModelType = .chat(.chatgpt),
+                         user: String? = nil,
+                         temperature: Double? = 1,
+                         topProbabilityMass: Double? = 0,
+                         choices: Int? = 1,
+                         stop: [String]? = nil,
+                         maxTokens: Int? = nil,
+                         presencePenalty: Double? = 0,
+                         frequencyPenalty: Double? = 0,
+                         completionHandler: @escaping (Result<OpenAI<MessageResult>, OpenAIError>) -> Void) {
         let endpoint = Endpoint.chat
-        let body = ChatConversation(messages: messages, model: model.modelName, maxTokens: maxTokens)
+        let body = ChatConversation(user: user,
+                                    messages: messages,
+                                    model: model.modelName,
+                                    temperature: temperature,
+                                    topProbabilityMass: topProbabilityMass,
+                                    choices: choices,
+                                    stop: stop,
+                                    maxTokens: maxTokens,
+                                    presencePenalty: presencePenalty,
+                                    frequencyPenalty: frequencyPenalty)
         let request = prepareRequest(endpoint, body: body)
         
         makeRequest(request: request) { result in
@@ -167,12 +194,38 @@ extension OpenAISwift {
     /// - Parameters:
     ///   - messages: Array of `ChatMessages`
     ///   - model: The Model to use, the only support model is `gpt-3.5-turbo`
+    ///   - user: A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+    ///   - temperature: What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. We generally recommend altering this or topProbabilityMass but not both.
+    ///   - topProbabilityMass: The OpenAI api equivalent of the "top_p" parameter. An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both.
+    ///   - choices: How many chat completion choices to generate for each input message.
+    ///   - stop: Up to 4 sequences where the API will stop generating further tokens.
+    ///   - maxTokens: The maximum number of tokens allowed for the generated answer. By default, the number of tokens the model can return will be (4096 - prompt tokens).
+    ///   - presencePenalty: Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.
+    ///   - frequencyPenalty: Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.
     ///   - completionHandler: Returns an OpenAI Data Model
     @available(swift 5.5)
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-    public func sendChat(with messages: [ChatMessage], model: OpenAIModelType = .chat(.chatgpt), maxTokens: Int? = nil) async throws -> OpenAI<MessageResult> {
+    public func sendChat(with messages: [ChatMessage],
+                         model: OpenAIModelType = .chat(.chatgpt),
+                         user: String? = nil,
+                         temperature: Double? = 1,
+                         topProbabilityMass: Double? = 0,
+                         choices: Int? = 1,
+                         stop: [String]? = nil,
+                         maxTokens: Int? = nil,
+                         presencePenalty: Double? = 0,
+                         frequencyPenalty: Double? = 0) async throws -> OpenAI<MessageResult> {
         return try await withCheckedThrowingContinuation { continuation in
-            sendChat(with: messages, model: model, maxTokens: maxTokens) { result in
+            sendChat(with: messages,
+                     model: model,
+                     user: user,
+                     temperature: temperature,
+                     topProbabilityMass: topProbabilityMass,
+                     choices: choices,
+                     stop: stop,
+                     maxTokens: maxTokens,
+                     presencePenalty: presencePenalty,
+                     frequencyPenalty: frequencyPenalty) { result in
                 continuation.resume(with: result)
             }
         }


### PR DESCRIPTION
Added the following to the ChatConversation, and both sendChat functions:
- user
- temperature
- topProbabilityMass (top_p)
- choices (n)
- stop
- presencePenalty (presence_penalty)
- frequencyPenalty (frequency_penalty)

Corresponding strings have been added to the CodingKeys in ChatConversation.
All added parameters are optional values, and do not have to be added when calling sendChat.

Note that the following parameters still need to be added:
- stream
- logit_bias

The stream parameter makes it so that tokens are sent as [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format). This may require the use of another library such as https://github.com/inaka/EventSource.
