### PR TITLE
Adding chat-specific error handling

### DIFF
--- a/Sources/OpenAISwift/Models/ChatMessage.swift
+++ b/Sources/OpenAISwift/Models/ChatMessage.swift
@@ -33,5 +33,12 @@ public struct ChatConversation: Encodable {
         case maxTokens = "max_tokens"
         case temperature
     }
+}
 
+public struct ChatError: Codable {
+    public struct Payload: Codable {
+        public let message, type, param, code: String
+    }
+    
+    public let error: Payload
 }

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -7,6 +7,7 @@ import FoundationXML
 public enum OpenAIError: Error {
     case genericError(error: Error)
     case decodingError(error: Error)
+    case chatError(error: ChatError.Payload)
 }
 
 public class OpenAISwift {
@@ -88,9 +89,19 @@ extension OpenAISwift {
                     do {
                         let res = try JSONDecoder().decode(OpenAI<MessageResult>.self, from: success)
                         completionHandler(.success(res))
+                        return
+                    } catch {
+                        // Do nothing, we want to try decoding the ChatError before throwing in the towel.
+                    }
+                    
+                    do {
+                        let chatErr = try JSONDecoder().decode(ChatError.self, from: success) as ChatError
+                        completionHandler(.failure(.chatError(error: chatErr.error)))
+                        
                     } catch {
                         completionHandler(.failure(.decodingError(error: error)))
                     }
+                    
                 case .failure(let failure):
                     completionHandler(.failure(.genericError(error: failure)))
             }
@@ -176,7 +187,10 @@ extension OpenAISwift {
     public func sendChat(with messages: [ChatMessage], model: OpenAIModelType = .chat(.chatgpt), maxTokens: Int? = nil, temperature: Double = 1.0) async throws -> OpenAI<MessageResult> {
         return try await withCheckedThrowingContinuation { continuation in
             sendChat(with: messages, model: model, maxTokens: maxTokens, temperature: temperature) { result in
-                continuation.resume(with: result)
+                switch result {
+                    case .success: continuation.resume(with: result)
+                    case .failure(let failure): continuation.resume(throwing: failure)
+                }
             }
         }
     }


### PR DESCRIPTION
Added a case to the existing `OpenAIError` to handle errors returned by the new 'chat' model.