### PR TITLE
Add Image Generation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ openAI.sendCompletion(with: "A random emoji", model: .gpt3(.ada)) { result in //
 ```
 For a full list of the supported models see [OpenAIModelType.swift](https://github.com/adamrushy/OpenAISwift/blob/main/Sources/OpenAISwift/Models/OpenAIModelType.swift). For more information on the models see the [OpenAI API Documentation](https://beta.openai.com/docs/models).
 
+Generate an image using the images API:
+
+```swift
+openAI.sendImages(with: "A 3d render of a rocket ship", numImages: 1, size: .size1024) { result in // Result<OpenAI, OpenAIError>
+    switch result {
+    case .success(let success):
+        print(success.data.first?.url ?? "")
+    case .failure(let failure):
+        print(failure.localizedDescription)
+    }
+}
+```
+
 OpenAISwift also supports Swift concurrency so you can use Swift’s async/await syntax to fetch completions.
 
 ```swift

--- a/Sources/OpenAISwift/Models/ImageGeneration.swift
+++ b/Sources/OpenAISwift/Models/ImageGeneration.swift
@@ -1,0 +1,21 @@
+//
+//  ImageGeneration.swift
+//  
+//
+//  Created by Arjun Dureja on 2023-03-11.
+//
+
+import Foundation
+
+struct ImageGeneration: Encodable {
+    let prompt: String
+    let n: Int
+    let size: ImageSize
+    let user: String?
+}
+
+public enum ImageSize: String, Codable {
+    case size1024 = "1024x1024"
+    case size512 = "512x512"
+    case size256 = "256x256"
+}

--- a/Sources/OpenAISwift/Models/OpenAI.swift
+++ b/Sources/OpenAISwift/Models/OpenAI.swift
@@ -7,10 +7,11 @@ import Foundation
 public protocol Payload: Codable { }
 
 public struct OpenAI<T: Payload>: Codable {
-    public let object: String
+    public let object: String?
     public let model: String?
-    public let choices: [T]
-    public let usage: UsageResult
+    public let choices: [T]?
+    public let usage: UsageResult?
+    public let data: [T]?
 }
 
 public struct TextResult: Payload {
@@ -31,4 +32,8 @@ public struct UsageResult: Codable {
         case completionTokens = "completion_tokens"
         case totalTokens = "total_tokens"
     }
+}
+
+public struct UrlResult: Payload {
+    public let url: String
 }

--- a/Sources/OpenAISwift/OpenAIEndpoint.swift
+++ b/Sources/OpenAISwift/OpenAIEndpoint.swift
@@ -8,6 +8,7 @@ enum Endpoint {
     case completions
     case edits
     case chat
+    case images
 }
 
 extension Endpoint {
@@ -19,19 +20,21 @@ extension Endpoint {
                 return "/v1/edits"
             case .chat:
                 return "/v1/chat/completions"
+            case .images:
+                return "/v1/images/generations"
         }
     }
     
     var method: String {
         switch self {
-            case .completions, .edits, .chat:
+            case .completions, .edits, .chat, .images:
             return "POST"
         }
     }
     
     func baseURL() -> String {
         switch self {
-            case .completions, .edits, .chat:
+            case .completions, .edits, .chat, .images:
             return "https://api.openai.com"
         }
     }


### PR DESCRIPTION
Added the `v1/images/generations` API to generate images: https://platform.openai.com/docs/api-reference/images/create

Usage: 

```
openAI.sendImages(with: "A 3d render of a rocket ship", numImages: 1, size: .size1024) { result in // Result<OpenAI, OpenAIError>
    switch result {
    case .success(let success):
        print(success.data.first?.url ?? "")
    case .failure(let failure):
        print(failure.localizedDescription)
    }
}
```

Demo:


https://user-images.githubusercontent.com/16995513/224520411-b0525ef9-920c-46b6-903b-89a80026c6ce.mov

