### PR TITLE
Add `usage` to `OpenAI` payload struct

### DIFF
--- a/Sources/OpenAISwift/Models/OpenAI.swift
+++ b/Sources/OpenAISwift/Models/OpenAI.swift
@@ -10,6 +10,7 @@ public struct OpenAI<T: Payload>: Codable {
     public let object: String
     public let model: String?
     public let choices: [T]
+    public let usage: UsageResult
 }
 
 public struct TextResult: Payload {
@@ -18,4 +19,10 @@ public struct TextResult: Payload {
 
 public struct MessageResult: Payload {
     public let message: ChatMessage
+}
+
+public struct UsageResult: Payload {
+    public var prompt_tokens: Int
+    public var completion_tokens: Int
+    public var total_tokens: Int
 }


### PR DESCRIPTION
This way, we can track tokens usage for `sendEdits`, `sendCompletion`, and `sendChats`.