### PR TITLE
Add `usage` to `OpenAI` payload struct

### DIFF
--- a/Sources/OpenAISwift/Models/OpenAI.swift
+++ b/Sources/OpenAISwift/Models/OpenAI.swift
@@ -10,6 +10,7 @@ public struct OpenAI<T: Payload>: Codable {
     public let object: String
     public let model: String?
     public let choices: [T]
+    public let usage: UsageResult
 }
 
 public struct TextResult: Payload {
@@ -18,4 +19,10 @@ public struct TextResult: Payload {
 
 public struct MessageResult: Payload {
     public let message: ChatMessage
+}
+
+public struct UsageResult: Payload {
+    public let prompt_tokens: Int
+    public let completion_tokens: Int
+    public let total_tokens: Int
 }

--- a/Sources/OpenAISwift/Models/OpenAI.swift
+++ b/Sources/OpenAISwift/Models/OpenAI.swift
@@ -22,7 +22,13 @@ public struct MessageResult: Payload {
 }
 
 public struct UsageResult: Payload {
-    public let prompt_tokens: Int
-    public let completion_tokens: Int
-    public let total_tokens: Int
+    public let promptTokens: Int
+    public let completionTokens: Int
+    public let totalTokens: Int
+
+    enum CodingKeys: String, CodingKey {
+        case promptTokens = "prompt_tokens"
+        case completionTokens = "completion_tokens"
+        case totalTokens = "total_tokens"
+    }
 }

--- a/Sources/OpenAISwift/Models/OpenAI.swift
+++ b/Sources/OpenAISwift/Models/OpenAI.swift
@@ -21,7 +21,7 @@ public struct MessageResult: Payload {
     public let message: ChatMessage
 }
 
-public struct UsageResult: Payload {
+public struct UsageResult: Codable {
     public let promptTokens: Int
     public let completionTokens: Int
     public let totalTokens: Int


### PR DESCRIPTION
Hi, I enjoyed working with your library. but I wanted to know how many tokens I've used,
so I made a very small change:
```swift
public struct OpenAI<T: Payload>: Codable {
    public let object: String
    public let model: String?
    public let choices: [T]
    public let usage: UsageResult
}

public struct UsageResult: Payload {
    public let prompt_tokens: Int
    public let completion_tokens: Int
    public let total_tokens: Int
}
```
This way, we can track tokens usage for `sendEdits`, `sendCompletion`, and `sendChats` without changing anything else.