### PR TITLE
Make the session configurable through a Config struct

### DIFF
--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -11,9 +11,23 @@ public enum OpenAIError: Error {
 
 public class OpenAISwift {
     fileprivate(set) var token: String?
+    fileprivate let config: Config
     
-    public init(authToken: String) {
+    /// Configuration object for the client
+    public struct Config {
+        
+        /// Initialiser
+        /// - Parameter session: the session to use for network requests.
+        public init(session: URLSession = URLSession.shared) {
+            self.session = session
+        }
+
+        let session:URLSession
+    }
+    
+    public init(authToken: String,config:Config = Config()) {
         self.token = authToken
+        self.config = Config()
     }
 }
 
@@ -98,7 +112,7 @@ extension OpenAISwift {
     }
     
     private func makeRequest(request: URLRequest, completionHandler: @escaping (Result<Data, Error>) -> Void) {
-        let session = URLSession.shared
+        let session = config.session
         let task = session.dataTask(with: request) { (data, response, error) in
             if let error = error {
                 completionHandler(.failure(error))

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -25,7 +25,7 @@ public class OpenAISwift {
         let session:URLSession
     }
     
-    public init(authToken: String,config:Config = Config()) {
+    public init(authToken: String, config: Config = Config()) {
         self.token = authToken
         self.config = Config()
     }


### PR DESCRIPTION
This adds an optional Config struct to the client initialisation. 

At the moment, the only configurable item is the URLSession to use - but this is easily extendable in future. 
Provided there is always a default Config in the initialiser, this can be ignored by most users.

In my case, I want to change the default timeout, but there could be a bunch of different reasons to control the URLSession in use.