### PR TITLE
Add support for `logit_bias` and improve documentation

### DIFF
--- a/Sources/OpenAISwift/Models/ChatMessage.swift
+++ b/Sources/OpenAISwift/Models/ChatMessage.swift
@@ -67,7 +67,7 @@ public struct ChatConversation: Encodable {
     let frequencyPenalty: Double?
 
     /// Modify the likelihood of specified tokens appearing in the completion. Maps tokens (specified by their token ID in the OpenAI Tokenizer—not English words) to an associated bias value from -100 to 100. Values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.
-    let logitBias: [String: Double]?
+    let logitBias: [Int: Double]?
 
     enum CodingKeys: String, CodingKey {
         case user

--- a/Sources/OpenAISwift/Models/ChatMessage.swift
+++ b/Sources/OpenAISwift/Models/ChatMessage.swift
@@ -7,31 +7,67 @@
 
 import Foundation
 
+/// An enumeration of possible roles in a chat conversation.
 public enum ChatRole: String, Codable {
-    case system, user, assistant
+    /// The role for the system that manages the chat interface.
+    case system
+    /// The role for the human user who initiates the chat.
+    case user
+    /// The role for the artificial assistant who responds to the user.
+    case assistant
 }
 
+/// A structure that represents a single message in a chat conversation.
 public struct ChatMessage: Codable {
+    /// The role of the sender of the message.
     public let role: ChatRole
+    /// The content of the message.
     public let content: String
-    
+
+    /// Creates a new chat message with a given role and content.
+    /// - Parameters:
+    ///   - role: The role of the sender of the message.
+    ///   - content: The content of the message.
     public init(role: ChatRole, content: String) {
         self.role = role
         self.content = content
     }
 }
 
+/// A structure that represents a chat conversation.
 public struct ChatConversation: Encodable {
+    /// The name or identifier of the user who initiates the chat. Optional if not provided by the user interface.
     let user: String?
+
+    /// The messages to generate chat completions for. Ordered chronologically from oldest to newest.
     let messages: [ChatMessage]
+
+    /// The ID of the model used by the assistant to generate responses. See OpenAI documentation for details on which models work with the Chat API.
     let model: String
+
+    /// A parameter that controls how random or deterministic the responses are, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. Optional, defaults to 1.
     let temperature: Double?
+
+    /// A parameter that controls how diverse or narrow-minded the responses are, between 0 and 1. Higher values like 0.9 mean only the tokens comprising the top 90% probability mass are considered, while lower values like 0.1 mean only the top 10%. Optional, defaults to 1.
     let topProbabilityMass: Double?
+
+    /// How many chat completion choices to generate for each input message. Optional, defaults to 1.
     let choices: Int?
+
+    /// An array of up to 4 sequences where the API will stop generating further tokens. Optional.
     let stop: [String]?
+
+    /// The maximum number of tokens to generate in the chat completion. The total length of input tokens and generated tokens is limited by the model's context length. Optional.
     let maxTokens: Int?
+
+    /// A parameter that penalizes new tokens based on whether they appear in the text so far, between -2 and 2. Positive values increase the model's likelihood to talk about new topics. Optional if not specified by default or by user input. Optional, defaults to 0.
     let presencePenalty: Double?
+
+    /// A parameter that penalizes new tokens based on their existing frequency in the text so far, between -2 and 2. Positive values decrease the model's likelihood to repeat the same line verbatim. Optional if not specified by default or by user input. Optional, defaults to 0.
     let frequencyPenalty: Double?
+
+    /// Modify the likelihood of specified tokens appearing in the completion. Maps tokens (specified by their token ID in the OpenAI Tokenizer—not English words) to an associated bias value from -100 to 100. Values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.
+    let logitBias: [String: Double]?
 
     enum CodingKeys: String, CodingKey {
         case user
@@ -44,6 +80,6 @@ public struct ChatConversation: Encodable {
         case maxTokens = "max_tokens"
         case presencePenalty = "presence_penalty"
         case frequencyPenalty = "frequency_penalty"
+        case logitBias = "logit_bias"
     }
-
 }

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -206,6 +206,7 @@ extension OpenAISwift {
     ///   - maxTokens: The maximum number of tokens allowed for the generated answer. By default, the number of tokens the model can return will be (4096 - prompt tokens).
     ///   - presencePenalty: Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.
     ///   - frequencyPenalty: Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.
+    ///   - logitBias: Modify the likelihood of specified tokens appearing in the completion. Maps tokens (specified by their token ID in the OpenAI Tokenizer—not English words) to an associated bias value from -100 to 100. Values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.
     ///   - completionHandler: Returns an OpenAI Data Model
     @available(swift 5.5)
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
@@ -218,7 +219,8 @@ extension OpenAISwift {
                          stop: [String]? = nil,
                          maxTokens: Int? = nil,
                          presencePenalty: Double? = 0,
-                         frequencyPenalty: Double? = 0) async throws -> OpenAI<MessageResult> {
+                         frequencyPenalty: Double? = 0,
+                         logitBias: [Int: Double]?) async throws -> OpenAI<MessageResult> {
         return try await withCheckedThrowingContinuation { continuation in
             sendChat(with: messages,
                      model: model,
@@ -229,7 +231,8 @@ extension OpenAISwift {
                      stop: stop,
                      maxTokens: maxTokens,
                      presencePenalty: presencePenalty,
-                     frequencyPenalty: frequencyPenalty) { result in
+                     frequencyPenalty: frequencyPenalty,
+                     logitBias: logitBias) { result in
                 continuation.resume(with: result)
             }
         }

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -82,6 +82,7 @@ extension OpenAISwift {
     ///   - maxTokens: The maximum number of tokens allowed for the generated answer. By default, the number of tokens the model can return will be (4096 - prompt tokens).
     ///   - presencePenalty: Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.
     ///   - frequencyPenalty: Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.
+    ///   - logitBias: Modify the likelihood of specified tokens appearing in the completion. Maps tokens (specified by their token ID in the OpenAI Tokenizer—not English words) to an associated bias value from -100 to 100. Values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.
     ///   - completionHandler: Returns an OpenAI Data Model
     public func sendChat(with messages: [ChatMessage],
                          model: OpenAIModelType = .chat(.chatgpt),
@@ -93,6 +94,7 @@ extension OpenAISwift {
                          maxTokens: Int? = nil,
                          presencePenalty: Double? = 0,
                          frequencyPenalty: Double? = 0,
+                         logitBias: [String: Double]? = nil,
                          completionHandler: @escaping (Result<OpenAI<MessageResult>, OpenAIError>) -> Void) {
         let endpoint = Endpoint.chat
         let body = ChatConversation(user: user,
@@ -104,7 +106,8 @@ extension OpenAISwift {
                                     stop: stop,
                                     maxTokens: maxTokens,
                                     presencePenalty: presencePenalty,
-                                    frequencyPenalty: frequencyPenalty)
+                                    frequencyPenalty: frequencyPenalty,
+                                    logitBias: logitBias)
 
         let request = prepareRequest(endpoint, body: body)
         

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -94,7 +94,7 @@ extension OpenAISwift {
                          maxTokens: Int? = nil,
                          presencePenalty: Double? = 0,
                          frequencyPenalty: Double? = 0,
-                         logitBias: [String: Double]? = nil,
+                         logitBias: [Int: Double]? = nil,
                          completionHandler: @escaping (Result<OpenAI<MessageResult>, OpenAIError>) -> Void) {
         let endpoint = Endpoint.chat
         let body = ChatConversation(user: user,

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -220,7 +220,7 @@ extension OpenAISwift {
                          maxTokens: Int? = nil,
                          presencePenalty: Double? = 0,
                          frequencyPenalty: Double? = 0,
-                         logitBias: [Int: Double]?) async throws -> OpenAI<MessageResult> {
+                         logitBias: [Int: Double]? = nil) async throws -> OpenAI<MessageResult> {
         return try await withCheckedThrowingContinuation { continuation in
             sendChat(with: messages,
                      model: model,


### PR DESCRIPTION
See [OpenAI documentation](https://platform.openai.com/docs/api-reference/chat/create#chat/create-logit_bias) on `logit_bias`:

> Modify the likelihood of specified tokens appearing in the completion.

> Accepts a json object that maps tokens (specified by their token ID in the tokenizer) to an associated bias value from -100 to 100. Mathematically, the bias is added to the logits generated by the model prior to sampling. The exact effect will vary per model, but values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.