### PR TITLE
Added support for other custom models

### DIFF
--- a/Sources/OpenAISwift/Models/OpenAIModelType.swift
+++ b/Sources/OpenAISwift/Models/OpenAIModelType.swift
@@ -15,10 +15,10 @@ public enum OpenAIModelType {
     /// ``Codex`` Family of Models
     case codex(Codex)
     
-    /// ``Feature``Family of Models
+    /// ``Feature`` Family of Models
     case feature(Feature)
     
-    /// ``Chat``Family of Models
+    /// ``Chat`` Family of Models
     case chat(Chat)
     
     /// Other Custom Models

--- a/Sources/OpenAISwift/Models/OpenAIModelType.swift
+++ b/Sources/OpenAISwift/Models/OpenAIModelType.swift
@@ -21,12 +21,16 @@ public enum OpenAIModelType {
     /// ``Chat``Family of Models
     case chat(Chat)
     
+    /// Other Custom Models
+    case other(String)
+    
     public var modelName: String {
         switch self {
         case .gpt3(let model): return model.rawValue
         case .codex(let model): return model.rawValue
         case .feature(let model): return model.rawValue
         case .chat(let model): return model.rawValue
+        case .other(let modelName): return modelName
         }
     }
     


### PR DESCRIPTION
This escape hatch allows to use models currently in beta like `gpt-4` or `gpt-4-32k-0314`, for example.