### PR TITLE
[ChatError] Fixed implementation

### DIFF
--- a/Sources/OpenAISwift/Models/ChatMessage.swift
+++ b/Sources/OpenAISwift/Models/ChatMessage.swift
@@ -86,7 +86,8 @@ public struct ChatConversation: Encodable {
 
 public struct ChatError: Codable {
     public struct Payload: Codable {
-        public let message, type, param, code: String
+        public let message, type: String
+        public let param, code: String?
     }
     
     public let error: Payload


### PR DESCRIPTION
This fixes the implementation of #43:
- The `param` and `code` error fields are optional.
- We have to check if there is a `ChatError` before we try to decode the `OpenAI` response, as the later always succeds due to [this change](https://github.com/adamrushy/OpenAISwift/commit/0d558a0e7aae33dc8cac1ba6db876ff9b919171b#diff-fef3ee60b3f97818fb624c5369bebb4acc38d0813020abcdfa33c7796da871b4R9).