### PR TITLE
Make completionTokens optional

### DIFF
--- a/Sources/OpenAISwift/Models/OpenAI.swift
+++ b/Sources/OpenAISwift/Models/OpenAI.swift
@@ -24,7 +24,7 @@ public struct MessageResult: Payload {
 
 public struct UsageResult: Codable {
     public let promptTokens: Int
-    public let completionTokens: Int
+    public let completionTokens: Int?
     public let totalTokens: Int
 
     enum CodingKeys: String, CodingKey {


### PR DESCRIPTION
In the case where the completion returns an empty string, no completion tokens are used. 

This results in a decoding error from the missing key for completion_tokens:
keyNotFound(CodingKeys(stringValue: "completion_tokens", intValue: nil), Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "usage", intValue: nil)], debugDescription: "No value associated with key CodingKeys(stringValue: \"completion_tokens\", intValue: nil) (\"completion_tokens\").", underlyingError: nil))