### PR TITLE
sendModeration endpoint

### DIFF
--- a/Sources/OpenAISwift/Models/Moderation.swift
+++ b/Sources/OpenAISwift/Models/Moderation.swift
@@ -1,0 +1,10 @@
+//
+//  Created by Michael Watts on 5/15/23.
+//
+
+import Foundation
+
+struct Moderation: Encodable {
+    let input: String
+    let model: String
+}

--- a/Sources/OpenAISwift/Models/OpenAI.swift
+++ b/Sources/OpenAISwift/Models/OpenAI.swift
@@ -12,6 +12,7 @@ public struct OpenAI<T: Payload>: Codable {
     public let choices: [T]?
     public let usage: UsageResult?
     public let data: [T]?
+    public let results: [T]?
 }
 
 public struct TextResult: Payload {
@@ -40,4 +41,8 @@ public struct UrlResult: Payload {
 
 public struct EmbeddingResult: Payload {
     public let embedding: [Double]
+}
+
+public struct ModerationResult: Payload {
+    public let flagged: Bool?
 }

--- a/Sources/OpenAISwift/Models/OpenAIModelType.swift
+++ b/Sources/OpenAISwift/Models/OpenAIModelType.swift
@@ -24,6 +24,9 @@ public enum OpenAIModelType {
     /// ``Embedding`` Family of Models
     case embedding(Embedding)
     
+    /// ``Moderation`` Family of Models
+    case moderation(Moderation)
+    
     /// Other Custom Models
     case other(String)
     
@@ -34,6 +37,7 @@ public enum OpenAIModelType {
         case .feature(let model): return model.rawValue
         case .chat(let model): return model.rawValue
         case .embedding(let model): return model.rawValue
+        case .moderation(let model): return model.rawValue
         case .other(let modelName): return modelName
         }
     }
@@ -114,5 +118,16 @@ public enum OpenAIModelType {
         ///
         /// > Model Name: text-embedding-ada-002
         case ada = "text-embedding-ada-002"
+    }
+    
+    /// A set of models for the moderations endpoint
+    /// You can read the [API Docs](https://platform.openai.com/docs/api-reference/moderations)
+    public enum Moderation: String {
+        /// Default. Automatically upgraded over time.
+        case latest = "text-moderation-latest"
+        
+        /// OpenAI will provide advanced notice before updating this model.
+        /// Accuracy  may be slightly lower than for text-moderation-latest.
+        case stable = "text-moderation-stable"
     }
 }

--- a/Sources/OpenAISwift/OpenAIEndpoint.swift
+++ b/Sources/OpenAISwift/OpenAIEndpoint.swift
@@ -10,6 +10,7 @@ enum Endpoint {
     case chat
     case images
     case embeddings
+    case moderations
 }
 
 extension Endpoint {
@@ -24,20 +25,22 @@ extension Endpoint {
             case .images:
                 return "/v1/images/generations"
             case .embeddings:
-            return "/v1/embeddings"
+                return "/v1/embeddings"
+            case .moderations:
+                return "/v1/moderations"
         }
     }
     
     var method: String {
         switch self {
-            case .completions, .edits, .chat, .images, .embeddings:
+            case .completions, .edits, .chat, .images, .embeddings, .moderations:
             return "POST"
         }
     }
     
     func baseURL() -> String {
         switch self {
-            case .completions, .edits, .chat, .images, .embeddings:
+            case .completions, .edits, .chat, .images, .embeddings, .moderations:
             return "https://api.openai.com"
         }
     }


### PR DESCRIPTION
Simple implementation of moderation API: https://platform.openai.com/docs/api-reference/moderations

Only models the `flagged` response field, not `categories` or `category_scores`. That could be added later.

Addresses https://github.com/adamrushy/OpenAISwift/issues/74