### PR TITLE
Add id property to ChatMessage to conform to Identifiable protocol

### DIFF
--- a/Sources/OpenAISwift/Models/ChatMessage.swift
+++ b/Sources/OpenAISwift/Models/ChatMessage.swift
@@ -18,7 +18,9 @@ public enum ChatRole: String, Codable {
 }
 
 /// A structure that represents a single message in a chat conversation.
-public struct ChatMessage: Codable {
+public struct ChatMessage: Codable, Identifiable {
+    // uuid to conform to Identifiable protocol
+    public var id = UUID()
     /// The role of the sender of the message.
     public let role: ChatRole
     /// The content of the message.


### PR DESCRIPTION
## What

Add `id` property that contains UUID to `ChatMessage` protocol.

## Why

I think `ChatMessage` struct will be used in list components to show conversation with assistant and user.
One way to implement it in SwiftUI is to use the List (or other iterable) component. But this doesn't work because `ChatMessage` doesn't conform to `identifiable`.

```
struct ContentView: View {
    @State private var messages: [ChatMessage] = [
        ChatMessage(role: .system, content: "You are a helpful assistant."),
        ChatMessage(role: .user, content: "Who won the world series in 2020?"),
    ]

    var body: some View {
        VStack {
            List(messages) { m in   <-------- Initializer 'init(_:rowContent:)' requires that 'ChatMessage' conform to 'Identifiable'
                Text(m.content)
            }

        }
        .padding()
    }
}
```

Using `id: \.self` for `List` is usual to define identification manually if object doesn't conform to `Identifiable`, but it needs to support `Hashable` protocol and `ChatMessage` doesn't.

So my idea is to add `id` property with uuid and make `ChatMessage` conform to `Identifiable` protocol.

## How

Add `id` property that is initialized by `UUID()` method (I think it is usual way). And add `Identifiable` protocol to it.