### PR TITLE
Implementation of Endpoints for Image Edit and Image Variation

### DIFF
--- a/Sources/OpenAISwift/Models/ImageGeneration.swift
+++ b/Sources/OpenAISwift/Models/ImageGeneration.swift
@@ -14,6 +14,22 @@ struct ImageGeneration: Encodable {
     let user: String?
 }
 
+struct ImageEdit: Encodable {
+    let image: Data
+    let mask: Data?
+    let prompt: String
+    let n: Int
+    let size: ImageSize
+    let user: String?
+}
+
+struct ImageVariations: Encodable {
+    let image: Data
+    let n: Int
+    let size: ImageSize
+    let user: String?
+}
+
 public enum ImageSize: String, Codable {
     case size1024 = "1024x1024"
     case size512 = "512x512"

--- a/Sources/OpenAISwift/Models/ImageGeneration.swift
+++ b/Sources/OpenAISwift/Models/ImageGeneration.swift
@@ -15,8 +15,8 @@ struct ImageGeneration: Encodable {
 }
 
 struct ImageEdit: Encodable {
-    let image: Data
-    let mask: Data?
+    let image: String
+    let mask: String?
     let prompt: String
     let n: Int
     let size: ImageSize
@@ -24,7 +24,7 @@ struct ImageEdit: Encodable {
 }
 
 struct ImageVariations: Encodable {
-    let image: Data
+    let image: String
     let n: Int
     let size: ImageSize
     let user: String?

--- a/Sources/OpenAISwift/Models/ImageGeneration.swift
+++ b/Sources/OpenAISwift/Models/ImageGeneration.swift
@@ -15,8 +15,8 @@ struct ImageGeneration: Encodable {
 }
 
 struct ImageEdit: Encodable {
-    let image: String
-    let mask: String?
+    let image: Data
+    let mask: Data?
     let prompt: String
     let n: Int
     let size: ImageSize
@@ -24,7 +24,7 @@ struct ImageEdit: Encodable {
 }
 
 struct ImageVariations: Encodable {
-    let image: String
+    let image: Data
     let n: Int
     let size: ImageSize
     let user: String?

--- a/Sources/OpenAISwift/Models/OpenAI.swift
+++ b/Sources/OpenAISwift/Models/OpenAI.swift
@@ -39,14 +39,14 @@ public struct UsageResult: Codable {
     }
 }
 
-public struct DALLEResponse: Payload {
-    public let created: Int
-    public let data: [Photo]
-}
-
-public struct Photo: Codable {
-    public let url: String
-}
+//public struct DALLEResponse: Payload {
+//    public let created: Int
+//    public let data: [Photo]
+//}
+//
+//public struct Photo: Codable {
+//    public let url: String
+//}
 
 public struct UrlResult: Payload {
     public let url: String

--- a/Sources/OpenAISwift/Models/OpenAI.swift
+++ b/Sources/OpenAISwift/Models/OpenAI.swift
@@ -39,15 +39,6 @@ public struct UsageResult: Codable {
     }
 }
 
-//public struct DALLEResponse: Payload {
-//    public let created: Int
-//    public let data: [Photo]
-//}
-//
-//public struct Photo: Codable {
-//    public let url: String
-//}
-
 public struct UrlResult: Payload {
     public let url: String
 }

--- a/Sources/OpenAISwift/Models/OpenAI.swift
+++ b/Sources/OpenAISwift/Models/OpenAI.swift
@@ -39,13 +39,13 @@ public struct UsageResult: Codable {
     }
 }
 
-struct DALLEResponse: Decodable {
-    let created: Int
-    let data: [Photo]
+public struct DALLEResponse: Payload {
+    public let created: Int
+    public let data: [Photo]
 }
 
-struct Photo: Decodable {
-    let url: String
+public struct Photo: Codable {
+    public let url: String
 }
 
 public struct UrlResult: Payload {

--- a/Sources/OpenAISwift/Models/OpenAI.swift
+++ b/Sources/OpenAISwift/Models/OpenAI.swift
@@ -39,6 +39,15 @@ public struct UsageResult: Codable {
     }
 }
 
+struct DALLEResponse: Decodable {
+    let created: Int
+    let data: [Photo]
+}
+
+struct Photo: Decodable {
+    let url: String
+}
+
 public struct UrlResult: Payload {
     public let url: String
 }

--- a/Sources/OpenAISwift/OpenAIEndpoint.swift
+++ b/Sources/OpenAISwift/OpenAIEndpoint.swift
@@ -12,6 +12,8 @@ public struct OpenAIEndpointProvider {
         case images
         case embeddings
         case moderations
+        case imageedits
+        case imagevariations
     }
     
     public enum Source {
@@ -41,6 +43,10 @@ public struct OpenAIEndpointProvider {
                     return "/v1/embeddings"
                 case .moderations:
                     return "/v1/moderations"
+                case .imageedits:
+                    return "/v1/images/edits"
+                case .imagevariations:
+                    return "/v1/images/variations"
             }
         case let .proxy(path: pathClosure, method: _):
             return pathClosure(api)
@@ -51,7 +57,7 @@ public struct OpenAIEndpointProvider {
         switch source {
         case .openAI:
             switch api {
-            case .completions, .edits, .chat, .images, .embeddings, .moderations:
+            case .completions, .edits, .chat, .images, .embeddings, .moderations, .imageedits, .imagevariations:
                 return "POST"
             }
         case let .proxy(path: _, method: methodClosure):

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -305,20 +305,14 @@ extension OpenAISwift {
     public func sendImageEdit(image: Data, mask: Data?, with prompt: String, numImages: Int = 1, size: ImageSize = .size1024, user: String? = nil, completionHandler: @escaping (Result<OpenAI<UrlResult>, OpenAIError>) -> Void) {
         
         let endpoint = OpenAIEndpointProvider.API.imageedits
-//        let body = ImageEdit(image: image, mask: mask, prompt: prompt, n: numImages, size: size, user: user)
         let request = prepareMultipartFormDataRequest(endpoint, imageData: image, maskData: mask, prompt: "", n: numImages, size: size.rawValue)
 
         makeRequest(request: request) { result in
             switch result {
                 case .success(let success):
                     do {
-                        print(request)
-                        print(result)
-                        print(success)
-                        let res = try JSONDecoder().decode(DALLEResponse.self, from: success)
-                        print(res)
-//                        let res = try JSONDecoder().decode(OpenAI<UrlResult>.self, from: success)
-//                        completionHandler(.success(res))
+                        let res = try JSONDecoder().decode(OpenAI<UrlResult>.self, from: success)
+                        completionHandler(.success(res))
                     } catch {
                         completionHandler(.failure(.decodingError(error: error)))
                     }
@@ -339,7 +333,6 @@ extension OpenAISwift {
     
     public func sendImageVariations(image: Data, numImages: Int = 1, size: ImageSize = .size1024, user: String? = nil, completionHandler: @escaping (Result<OpenAI<UrlResult>, OpenAIError>) -> Void) {
         let endpoint = OpenAIEndpointProvider.API.imagevariations
-//        let body = ImageVariations(image: image, n: numImages, size: size, user: user)
         let request = prepareMultipartFormDataRequest(endpoint, imageData: image, maskData: nil, prompt: "", n: numImages, size: size.rawValue)
         makeRequest(request: request) { result in
             switch result {
@@ -352,10 +345,10 @@ extension OpenAISwift {
                         print("The data is not a valid UTF-8 string.")
                     }
                     
-                    let res = try JSONDecoder().decode(DALLEResponse.self, from: success)
-                    print(res)
-//                        let res = try JSONDecoder().decode(OpenAI<UrlResult>.self, from: success)
-//                    completionHandler(.success(res))
+//                    let res = try JSONDecoder().decode(DALLEResponse.self, from: success)
+//                    print(res)
+                    let res = try JSONDecoder().decode(OpenAI<UrlResult>.self, from: success)
+                    completionHandler(.success(res))
                 } catch {
                     completionHandler(.failure(.decodingError(error: error)))
                 }

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -312,6 +312,9 @@ extension OpenAISwift {
             switch result {
                 case .success(let success):
                     do {
+                        print(request)
+                        print(result)
+                        print(success)
                         let res = try JSONDecoder().decode(OpenAI<UrlResult>.self, from: success)
                         completionHandler(.success(res))
                     } catch {
@@ -341,6 +344,10 @@ extension OpenAISwift {
             switch result {
                 case .success(let success):
                     do {
+                        print(request)
+                        print(result)
+                        print(success)
+
                         let res = try JSONDecoder().decode(OpenAI<UrlResult>.self, from: success)
                         completionHandler(.success(res))
                     } catch {

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -305,7 +305,7 @@ extension OpenAISwift {
     public func sendImageEdit(image: Data, mask: Data?, with prompt: String, numImages: Int = 1, size: ImageSize = .size1024, user: String? = nil, completionHandler: @escaping (Result<OpenAI<UrlResult>, OpenAIError>) -> Void) {
         
         let endpoint = OpenAIEndpointProvider.API.imageedits
-        let request = prepareMultipartFormDataRequest(endpoint, imageData: image, maskData: mask, prompt: "", n: numImages, size: size.rawValue)
+        let request = prepareMultipartFormDataRequest(endpoint, imageData: image, maskData: mask, prompt: prompt, n: numImages, size: size.rawValue)
 
         makeRequest(request: request) { result in
             switch result {

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -302,7 +302,7 @@ extension OpenAISwift {
     ///   - user: An optional unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
     ///   - completionHandler: Returns an OpenAI Data Model
 
-    public func sendImageEdit(image: Data, mask: Data?, with prompt: String, numImages: Int = 1, size: ImageSize = .size1024, user: String? = nil, completionHandler: @escaping (Result<OpenAI<UrlResult>, OpenAIError>) -> Void) {
+    public func sendImageEdit(image: String, mask: String?, with prompt: String, numImages: Int = 1, size: ImageSize = .size1024, user: String? = nil, completionHandler: @escaping (Result<OpenAI<UrlResult>, OpenAIError>) -> Void) {
         
         let endpoint = OpenAIEndpointProvider.API.images
         let body = ImageEdit(image: image, mask: mask, prompt: prompt, n: numImages, size: size, user: user)
@@ -332,7 +332,7 @@ extension OpenAISwift {
     ///   - completionHandler: Returns an OpenAI Data Model
 
     
-    public func sendImageVariations(image: Data, numImages: Int = 1, size: ImageSize = .size1024, user: String? = nil, completionHandler: @escaping (Result<OpenAI<UrlResult>, OpenAIError>) -> Void) {
+    public func sendImageVariations(image: String, numImages: Int = 1, size: ImageSize = .size1024, user: String? = nil, completionHandler: @escaping (Result<OpenAI<UrlResult>, OpenAIError>) -> Void) {
         let endpoint = OpenAIEndpointProvider.API.images
         let body = ImageVariations(image: image, n: numImages, size: size, user: user)
         let request = prepareRequest(endpoint, body: body)

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -311,6 +311,12 @@ extension OpenAISwift {
             switch result {
                 case .success(let success):
                     do {
+                        print(request)
+                        if let string = String(data: success, encoding: .utf8) {
+                            print(string)
+                        } else {
+                            print("The data is not a valid UTF-8 string.")
+                        }
                         let res = try JSONDecoder().decode(OpenAI<UrlResult>.self, from: success)
                         completionHandler(.success(res))
                     } catch {
@@ -345,9 +351,7 @@ extension OpenAISwift {
                         print("The data is not a valid UTF-8 string.")
                     }
                     
-//                    let res = try JSONDecoder().decode(DALLEResponse.self, from: success)
-//                    print(res)
-                    let res = try JSONDecoder().decode(OpenAI<UrlResult>.self, from: success)
+x                    let res = try JSONDecoder().decode(OpenAI<UrlResult>.self, from: success)
                     completionHandler(.success(res))
                 } catch {
                     completionHandler(.failure(.decodingError(error: error)))

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -304,7 +304,7 @@ extension OpenAISwift {
 
     public func sendImageEdit(image: String, mask: String?, with prompt: String, numImages: Int = 1, size: ImageSize = .size1024, user: String? = nil, completionHandler: @escaping (Result<OpenAI<UrlResult>, OpenAIError>) -> Void) {
         
-        let endpoint = OpenAIEndpointProvider.API.images
+        let endpoint = OpenAIEndpointProvider.API.imageedits
         let body = ImageEdit(image: image, mask: mask, prompt: prompt, n: numImages, size: size, user: user)
         let request = prepareRequest(endpoint, body: body)
 
@@ -333,7 +333,7 @@ extension OpenAISwift {
 
     
     public func sendImageVariations(image: String, numImages: Int = 1, size: ImageSize = .size1024, user: String? = nil, completionHandler: @escaping (Result<OpenAI<UrlResult>, OpenAIError>) -> Void) {
-        let endpoint = OpenAIEndpointProvider.API.images
+        let endpoint = OpenAIEndpointProvider.API.imagevariations
         let body = ImageVariations(image: image, n: numImages, size: size, user: user)
         let request = prepareRequest(endpoint, body: body)
 

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -302,7 +302,7 @@ extension OpenAISwift {
     ///   - user: An optional unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
     ///   - completionHandler: Returns an OpenAI Data Model
 
-    public func sendImageEdit(image: String, mask: String?, with prompt: String, numImages: Int = 1, size: ImageSize = .size1024, user: String? = nil, completionHandler: @escaping (Result<OpenAI<UrlResult>, OpenAIError>) -> Void) {
+    public func sendImageEdit(image: Data, mask: Data?, with prompt: String, numImages: Int = 1, size: ImageSize = .size1024, user: String? = nil, completionHandler: @escaping (Result<OpenAI<UrlResult>, OpenAIError>) -> Void) {
         
         let endpoint = OpenAIEndpointProvider.API.imageedits
         let body = ImageEdit(image: image, mask: mask, prompt: prompt, n: numImages, size: size, user: user)
@@ -332,7 +332,7 @@ extension OpenAISwift {
     ///   - completionHandler: Returns an OpenAI Data Model
 
     
-    public func sendImageVariations(image: String, numImages: Int = 1, size: ImageSize = .size1024, user: String? = nil, completionHandler: @escaping (Result<OpenAI<UrlResult>, OpenAIError>) -> Void) {
+    public func sendImageVariations(image: Data, numImages: Int = 1, size: ImageSize = .size1024, user: String? = nil, completionHandler: @escaping (Result<OpenAI<UrlResult>, OpenAIError>) -> Void) {
         let endpoint = OpenAIEndpointProvider.API.imagevariations
         let body = ImageVariations(image: image, n: numImages, size: size, user: user)
         let request = prepareRequest(endpoint, body: body)

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -351,7 +351,7 @@ extension OpenAISwift {
                         print("The data is not a valid UTF-8 string.")
                     }
                     
-x                    let res = try JSONDecoder().decode(OpenAI<UrlResult>.self, from: success)
+                    let res = try JSONDecoder().decode(OpenAI<UrlResult>.self, from: success)
                     completionHandler(.success(res))
                 } catch {
                     completionHandler(.failure(.decodingError(error: error)))

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -346,8 +346,11 @@ extension OpenAISwift {
             case .success(let success):
                 do {
                     print(request)
-                    print(result)
-                    print(success)
+                    if let string = String(data: success, encoding: .utf8) {
+                        print(string)
+                    } else {
+                        print("The data is not a valid UTF-8 string.")
+                    }
                     
                     let res = try JSONDecoder().decode(DALLEResponse.self, from: success)
                     print(res)

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -425,10 +425,13 @@ extension OpenAISwift {
         }
         
         // Add the "prompt" field.
-        body.append("--\(boundary)\r\n".data(using: .utf8)!)
-        body.append("Content-Disposition: form-data; name=\"prompt\"\r\n\r\n".data(using: .utf8)!)
-        body.append(prompt.data(using: .utf8)!)
-        body.append("\r\n".data(using: .utf8)!)
+        
+        if !prompt.isEmpty {
+            body.append("--\(boundary)\r\n".data(using: .utf8)!)
+            body.append("Content-Disposition: form-data; name=\"prompt\"\r\n\r\n".data(using: .utf8)!)
+            body.append(prompt.data(using: .utf8)!)
+            body.append("\r\n".data(using: .utf8)!)
+        }
         
         // Add the "n" field.
         body.append("--\(boundary)\r\n".data(using: .utf8)!)

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -302,7 +302,7 @@ extension OpenAISwift {
     ///   - user: An optional unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
     ///   - completionHandler: Returns an OpenAI Data Model
 
-    public func sendImageEdit(image: Data, mask: Data?, with prompt: String, numImages: Int = 1, size: ImageSize = .size1024, user: String? = nil, completionHandler: @escaping (Result<OpenAI<UrlResult>, OpenAIError>) -> Void) {
+    public func sendImageEdit(image: String, mask: String?, with prompt: String, numImages: Int = 1, size: ImageSize = .size1024, user: String? = nil, completionHandler: @escaping (Result<OpenAI<UrlResult>, OpenAIError>) -> Void) {
         
         let endpoint = OpenAIEndpointProvider.API.imageedits
         let body = ImageEdit(image: image, mask: mask, prompt: prompt, n: numImages, size: size, user: user)
@@ -332,7 +332,7 @@ extension OpenAISwift {
     ///   - completionHandler: Returns an OpenAI Data Model
 
     
-    public func sendImageVariations(image: Data, numImages: Int = 1, size: ImageSize = .size1024, user: String? = nil, completionHandler: @escaping (Result<OpenAI<UrlResult>, OpenAIError>) -> Void) {
+    public func sendImageVariations(image: String, numImages: Int = 1, size: ImageSize = .size1024, user: String? = nil, completionHandler: @escaping (Result<OpenAI<UrlResult>, OpenAIError>) -> Void) {
         let endpoint = OpenAIEndpointProvider.API.imagevariations
         let body = ImageVariations(image: image, n: numImages, size: size, user: user)
         let request = prepareRequest(endpoint, body: body)

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -293,14 +293,16 @@ extension OpenAISwift {
                 }
         }
     }
-    
-    func isPNG(data: Data) -> Bool {
-        let pngSignature: [UInt8] = [137, 80, 78, 71, 13, 10, 26, 10]
-        var dataSignature = [UInt8](repeating: 0, count: 8)
-        data.copyBytes(to: &dataSignature, count: 8)
-        return pngSignature == dataSignature
-    }
-    
+        
+    /// Send a Image Edit request to the OpenAI API
+    /// - Parameters:
+    ///   - image: The Image to be edited. - Must be less than 4MB.
+    ///   - mask: The mask area to be edited - Must be less than 4MB.
+    ///   - numImages: The number of images to generate, defaults to 1
+    ///   - size: The size of the image, defaults to 1024x1024. There are two other options: 512x512 and 256x256
+    ///   - user: An optional unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+    ///   - completionHandler: Returns an OpenAI Data Model
+
     public func sendImageEdit(image: Data, mask: Data?, with prompt: String, numImages: Int = 1, size: ImageSize = .size1024, user: String? = nil, completionHandler: @escaping (Result<OpenAI<UrlResult>, OpenAIError>) -> Void) {
         
         let endpoint = OpenAIEndpointProvider.API.images
@@ -321,6 +323,15 @@ extension OpenAISwift {
                 }
         }
     }
+    
+    /// Send a Image Variation request to the OpenAI API
+    /// - Parameters:
+    ///   - image: The Image to be varied. - Must be less than 4MB.
+    ///   - numImages: The number of images to generate, defaults to 1
+    ///   - size: The size of the image, defaults to 1024x1024. There are two other options: 512x512 and 256x256
+    ///   - user: An optional unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+    ///   - completionHandler: Returns an OpenAI Data Model
+
     
     public func sendImageVariations(image: Data, numImages: Int = 1, size: ImageSize = .size1024, user: String? = nil, completionHandler: @escaping (Result<OpenAI<UrlResult>, OpenAIError>) -> Void) {
         let endpoint = OpenAIEndpointProvider.API.images

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -305,8 +305,8 @@ extension OpenAISwift {
     public func sendImageEdit(image: Data, mask: Data?, with prompt: String, numImages: Int = 1, size: ImageSize = .size1024, user: String? = nil, completionHandler: @escaping (Result<OpenAI<UrlResult>, OpenAIError>) -> Void) {
         
         let endpoint = OpenAIEndpointProvider.API.imageedits
-        let body = ImageEdit(image: image, mask: mask, prompt: prompt, n: numImages, size: size, user: user)
-        let request = prepareRequest(endpoint, body: body)
+//        let body = ImageEdit(image: image, mask: mask, prompt: prompt, n: numImages, size: size, user: user)
+        let request = prepareMultipartFormDataRequest(endpoint, imageData: image, maskData: mask, prompt: "", n: numImages, size: size.rawValue)
 
         makeRequest(request: request) { result in
             switch result {
@@ -315,8 +315,10 @@ extension OpenAISwift {
                         print(request)
                         print(result)
                         print(success)
-                        let res = try JSONDecoder().decode(OpenAI<UrlResult>.self, from: success)
-                        completionHandler(.success(res))
+                        let res = try JSONDecoder().decode(DALLEResponse.self, from: success)
+                        print(res)
+//                        let res = try JSONDecoder().decode(OpenAI<UrlResult>.self, from: success)
+//                        completionHandler(.success(res))
                     } catch {
                         completionHandler(.failure(.decodingError(error: error)))
                     }
@@ -347,8 +349,10 @@ extension OpenAISwift {
                     print(result)
                     print(success)
                     
-                    let res = try JSONDecoder().decode(OpenAI<UrlResult>.self, from: success)
-                    completionHandler(.success(res))
+                    let res = try JSONDecoder().decode(DALLEResponse.self, from: success)
+                    print(res)
+//                        let res = try JSONDecoder().decode(OpenAI<UrlResult>.self, from: success)
+//                    completionHandler(.success(res))
                 } catch {
                     completionHandler(.failure(.decodingError(error: error)))
                 }

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -311,12 +311,6 @@ extension OpenAISwift {
             switch result {
                 case .success(let success):
                     do {
-                        print(request)
-                        if let string = String(data: success, encoding: .utf8) {
-                            print(string)
-                        } else {
-                            print("The data is not a valid UTF-8 string.")
-                        }
                         let res = try JSONDecoder().decode(OpenAI<UrlResult>.self, from: success)
                         completionHandler(.success(res))
                     } catch {
@@ -344,13 +338,6 @@ extension OpenAISwift {
             switch result {
             case .success(let success):
                 do {
-                    print(request)
-                    if let string = String(data: success, encoding: .utf8) {
-                        print(string)
-                    } else {
-                        print("The data is not a valid UTF-8 string.")
-                    }
-                    
                     let res = try JSONDecoder().decode(OpenAI<UrlResult>.self, from: success)
                     completionHandler(.success(res))
                 } catch {

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -5,7 +5,6 @@ import FoundationXML
 #endif
 
 public enum OpenAIError: Error {
-    case imageError(error: Error)
     case genericError(error: Error)
     case decodingError(error: Error)
     case chatError(error: ChatError.Payload)


### PR DESCRIPTION
I created another init() function which takes the old APIKEY and passes it to the new Config structure.

Because Images are handled by different libraries in IOS and MacOS, there is no error handling.

Images have to be the correct size (256x256, 512x512, 1024x1024 and less than 4MB)

Images must be png files and passed as image.pngData(). (same for the Mask in Image Edit endpoint)

For Editing, if no mask is supplied (its optional) then the image/png file MUST have an alpha channel. (RGBA). 

Any of the above Failures result in "Success" results, but "Errors" in the response, which aren't handled by the Decoder.