### PR TITLE
fix: Remove UUID from ChatMessage. 

### DIFF
--- a/Sources/OpenAISwift/Models/ChatMessage.swift
+++ b/Sources/OpenAISwift/Models/ChatMessage.swift
@@ -18,9 +18,7 @@ public enum ChatRole: String, Codable {
 }
 
 /// A structure that represents a single message in a chat conversation.
-public struct ChatMessage: Codable, Identifiable {
-    // uuid to conform to Identifiable protocol
-    public var id = UUID()
+public struct ChatMessage: Codable {
     /// The role of the sender of the message.
     public let role: ChatRole?
     /// The content of the message.


### PR DESCRIPTION
This solves the ""Additional properties are not allowed ('id' was unexpected) - 'messages.O'" bug. 
<img width="598" alt="Screenshot 2023-07-30 at 4 32 21 PM" src="https://github.com/adamrushy/OpenAISwift/assets/8249723/b3052251-f24f-41f4-ba98-966e24e35a77">
