### PR TITLE
Add explicit codable implementation to ChatMessage

### DIFF
--- a/Sources/OpenAISwift/Models/ChatMessage.swift
+++ b/Sources/OpenAISwift/Models/ChatMessage.swift
@@ -34,6 +34,28 @@ public struct ChatMessage: Codable, Identifiable {
         self.role = role
         self.content = content
     }
+
+    enum CodingKeys: CodingKey {
+        case id
+        case role
+        case content
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container: KeyedDecodingContainer<ChatMessage.CodingKeys> = try decoder.container(keyedBy: ChatMessage.CodingKeys.self)
+
+        self.id = UUID()
+        self.role = try container.decodeIfPresent(ChatRole.self, forKey: ChatMessage.CodingKeys.role)
+        self.content = try container.decodeIfPresent(String.self, forKey: ChatMessage.CodingKeys.content)
+
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container: KeyedEncodingContainer<ChatMessage.CodingKeys> = encoder.container(keyedBy: ChatMessage.CodingKeys.self)
+
+        try container.encodeIfPresent(self.role, forKey: ChatMessage.CodingKeys.role)
+        try container.encodeIfPresent(self.content, forKey: ChatMessage.CodingKeys.content)
+    }
 }
 
 /// A structure that represents a chat conversation.
@@ -70,7 +92,7 @@ public struct ChatConversation: Encodable {
 
     /// Modify the likelihood of specified tokens appearing in the completion. Maps tokens (specified by their token ID in the OpenAI Tokenizer—not English words) to an associated bias value from -100 to 100. Values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.
     let logitBias: [Int: Double]?
-    
+
     /// If you're generating long completions, waiting for the response can take many seconds. To get responses sooner, you can 'stream' the completion as it's being generated. This allows you to start printing or processing the beginning of the completion before the full completion is finished.
     /// https://github.com/openai/openai-cookbook/blob/main/examples/How_to_stream_completions.ipynb
     let stream: Bool?
@@ -96,6 +118,6 @@ public struct ChatError: Codable {
         public let message, type: String
         public let param, code: String?
     }
-    
+
     public let error: Payload
 }


### PR DESCRIPTION
Fixes #100  `Add explicit codable implementation to ChatMessage` without removing the `Identifiable` conformance by implementing an explicit coddle implementation that ignores the `id` property when encoding, and creates a new UUID when decoding.

This should fix the regular chat and streaming chat as both have not been working with the encoded `id`.