### PR TITLE
Fixed auth issue, restored old ini but flagged deprecated 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "OpenAISwift",
-    platforms: [.iOS(.v15), .macOS(.v10_15)],
+    platforms: [.iOS(.v13), .macOS(.v10_15)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/OpenAISwift/Models/ChatMessage.swift
+++ b/Sources/OpenAISwift/Models/ChatMessage.swift
@@ -34,6 +34,24 @@ public struct ChatMessage: Codable, Identifiable {
         self.role = role
         self.content = content
     }
+    
+    // MARK: Codable
+    
+    private enum CodingKeys: String, CodingKey {
+        case role, content
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        role = try container.decode(ChatRole.self, forKey: .role)
+        content = try container.decode(String.self, forKey: .content)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(self.role, forKey: .role)
+        try container.encodeIfPresent(self.content, forKey: .content)
+    }
 }
 
 /// A structure that represents a chat conversation.

--- a/Sources/OpenAISwift/OpenAISwift.swift
+++ b/Sources/OpenAISwift/OpenAISwift.swift
@@ -40,6 +40,11 @@ public class OpenAISwift {
         }
     }
     
+    @available(*, deprecated, message: "Use init(config:) instead")
+    public convenience init(authToken: String) {
+        self.init(config: .makeDefaultOpenAI(apiKey: authToken))
+    }
+    
     public init(config: Config) {
         self.config = config
     }


### PR DESCRIPTION
- Fixed auth issue due to **ChatMessage** **Codable** & **Identifiable** yet OpenAI does reject authorisation due to _additional properties are not allowed_
- Restored old init but flagged as deprecated to don't break compatibility
- Reduced system requirement to iOS 13